### PR TITLE
Add CI validation stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,55 +73,6 @@ validate_agent: &validate_agent
 jobs:
   include:
 
-    ###########################
-    # Linux : clang sanitizer #
-    ###########################
-
-    - <<: *validate_agent
-      stage: validate
-      name: "Linux clang++-6.0 Undefined Behavior Sanitizer"
-      env:
-        - C_COMPILER=clang-6.0
-        - CXX_COMPILER=clang++-6.0
-        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_UBSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
-
-    - <<: *validate_agent
-      stage: validate
-      name: "Linux clang++-6.0 Address Sanitizer"
-      env:
-        - C_COMPILER=clang-6.0
-        - CXX_COMPILER=clang++-6.0
-        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_ASAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
-
-    # - <<: *validate_agent
-    #   stage: validate
-    #   name: "Linux clang++-6.0 Memory Sanitizer"
-    #   env:
-    #     - C_COMPILER=clang-6.0
-    #     - CXX_COMPILER=clang++-6.0
-    #     - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_MSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
-
-    - <<: *validate_agent
-      stage: validate
-      name: "Linux clang++-6.0 Thread Sanitizer"
-      env:
-        - C_COMPILER=clang-6.0
-        - CXX_COMPILER=clang++-6.0
-        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_TSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
-
-    - stage: validate
-      name: "Linux g++-7 Code Coverage"
-      env:
-        - C_COMPILER=gcc-7
-        - CXX_COMPILER=g++-7
-        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_COVERAGE=1"
-      addons:
-        apt:
-          sources: ['ubuntu-toolchain-r-test']
-          packages: ['g++-7', 'ninja-build']
-      after_success:
-        - coveralls --build-root "$(pwd)/${build_directory}" -E ".*CMakeFiles.*" -e test -e test_package --gcov 'gcov-7' --gcov-options '\-lpr'
-
     ###############
     # Linux : GCC #
     ###############
@@ -340,6 +291,58 @@ jobs:
       name: "Deploy Doxygen"
       if: branch = master AND type = push
       script: .travis/deploy_doxygen.sh
+
+
+    ###########################
+    # Linux : clang sanitizer #
+    ###########################
+
+    - <<: *validate_agent
+      stage: validate
+      name: "Linux clang++-6.0 Undefined Behavior Sanitizer"
+      env:
+        - C_COMPILER=clang-6.0
+        - CXX_COMPILER=clang++-6.0
+        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_UBSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
+
+    - <<: *validate_agent
+      stage: validate
+      name: "Linux clang++-6.0 Address Sanitizer"
+      env:
+        - C_COMPILER=clang-6.0
+        - CXX_COMPILER=clang++-6.0
+        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_ASAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
+
+    # - <<: *validate_agent
+    #   stage: validate
+    #   name: "Linux clang++-6.0 Memory Sanitizer"
+    #   env:
+    #     - C_COMPILER=clang-6.0
+    #     - CXX_COMPILER=clang++-6.0
+    #     - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_MSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
+
+    - <<: *validate_agent
+      stage: validate
+      name: "Linux clang++-6.0 Thread Sanitizer"
+      env:
+        - C_COMPILER=clang-6.0
+        - CXX_COMPILER=clang++-6.0
+        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_TSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
+
+    - stage: validate
+      name: "Linux g++-7 Code Coverage"
+      os: linux
+      compiler: gcc
+      env:
+        - C_COMPILER=gcc-7
+        - CXX_COMPILER=g++-7
+        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_COVERAGE=1"
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-7', 'ninja-build']
+      after_success:
+        - coveralls --build-root "$(pwd)/${build_directory}" -E ".*CMakeFiles.*" -e test -e test_package --gcov 'gcov-7' --gcov-options '\-lpr'
 
 ##############################################################################
 # 1. Install Step

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,8 @@ branches:
 ##############################################################################
 
 stages:
-  - validate
   - test
+  - validate
   - deploy
 
 ##############################################################################
@@ -109,17 +109,18 @@ jobs:
         - CXX_COMPILER=clang++-6.0
         - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_TSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
 
-    # - <<: *validate_agent
-    #   stage: validate
-    #   name: "Linux g++-8 Code Coverage"
-    #   env:
-    #     - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_COVERAGE=1"
-
-    # - <<: *validate_agent
-    #   stage: validate
-    #   name: "Linux g++-8 Valgrind"
-    #   env:
-    #     - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_VALGRIND=1"
+    - stage: validate
+      name: "Linux g++-7 Code Coverage"
+      env:
+        - C_COMPILER=gcc-7
+        - CXX_COMPILER=g++-7
+        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_COVERAGE=1"
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-7', 'ninja-build']
+      after_success:
+        - coveralls --build-root "$(pwd)/${build_directory}" -E ".*CMakeFiles.*" -e test -e test_package --gcov 'gcov-7' --gcov-options '\-lpr'
 
     ###############
     # Linux : GCC #
@@ -363,6 +364,8 @@ install:
       sudo python3 -m pip install --upgrade --force setuptools
       sudo python3 -m pip install --upgrade --force pip
       python3 -m pip install --user conan
+      # This could be optimized by only installing on coveralls step...
+      python3 -m pip install --user cpp-coveralls==0.3.11
     fi
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ branches:
 ##############################################################################
 
 stages:
+  - validate
   - test
   - deploy
 
@@ -57,6 +58,14 @@ deploy_agent: &deploy_agent
       sources: ['ubuntu-toolchain-r-test']
       packages: ['g++-8', 'ninja-build']
 
+validate_agent: &validate_agent
+  os: linux
+  compiler: clang
+  addons:
+    apt:
+      sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
+      packages: ['g++-6', 'clang-6.0', 'ninja-build']
+
 ##############################################################################
 # Jobs
 ##############################################################################
@@ -68,22 +77,56 @@ jobs:
     # Linux : clang sanitizer #
     ###########################
 
-    # - name: "Linux clang++-6.0 Sanitizers"
-    #   os: linux
-    #   compiler: clang
+    - <<: *validate_agent
+      stage: validate
+      name: "Linux clang++-6.0 Undefined Behavior Sanitizer"
+      env:
+        - C_COMPILER=clang-6.0
+        - CXX_COMPILER=clang++-6.0
+        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_UBSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
+
+    - <<: *validate_agent
+      stage: validate
+      name: "Linux clang++-6.0 Address Sanitizer"
+      env:
+        - C_COMPILER=clang-6.0
+        - CXX_COMPILER=clang++-6.0
+        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_ASAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
+
+    # - <<: *validate_agent
+    #   stage: validate
+    #   name: "Linux clang++-6.0 Memory Sanitizer"
     #   env:
-    #     - COMPILER=clang++-6.0
-    #     - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_SANITIZER=On"
-    #   addons:
-    #     apt:
-    #       sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-trusty-6.0']
-    #       packages: ['g++-6', 'clang-6.0', 'ninja-build']
+    #     - C_COMPILER=clang-6.0
+    #     - CXX_COMPILER=clang++-6.0
+    #     - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_MSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
+
+    - <<: *validate_agent
+      stage: validate
+      name: "Linux clang++-6.0 Thread Sanitizer"
+      env:
+        - C_COMPILER=clang-6.0
+        - CXX_COMPILER=clang++-6.0
+        - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_TSAN=1 -DCMAKE_EXE_LINKER_FLAGS=-fuse-ld=gold"
+
+    # - <<: *validate_agent
+    #   stage: validate
+    #   name: "Linux g++-8 Code Coverage"
+    #   env:
+    #     - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_COVERAGE=1"
+
+    # - <<: *validate_agent
+    #   stage: validate
+    #   name: "Linux g++-8 Valgrind"
+    #   env:
+    #     - CMAKE_OPTIONS="-DBIT_CORE_ENABLE_VALGRIND=1"
 
     ###############
     # Linux : GCC #
     ###############
 
     - name: "Linux g++-5 unit tests"
+      stage: test
       os: linux
       compiler: gcc
       env:
@@ -95,6 +138,7 @@ jobs:
           packages: ['g++-5', 'ninja-build']
 
     - name: "Linux g++-6 unit tests"
+      stage: test
       os: linux
       compiler: gcc
       env:
@@ -106,6 +150,7 @@ jobs:
           packages: ['g++-6', 'ninja-build']
 
     - name: "Linux g++-7 unit tests"
+      stage: test
       os: linux
       compiler: gcc
       env:
@@ -117,6 +162,7 @@ jobs:
           packages: ['g++-7', 'ninja-build']
 
     - name: "Linux g++-8 unit tests"
+      stage: test
       os: linux
       compiler: gcc
       env:
@@ -132,6 +178,7 @@ jobs:
     #################
 
     - name: "Linux clang++-3.5 unit tests"
+      stage: test
       os: linux
       compiler: clang
       env:
@@ -143,6 +190,7 @@ jobs:
           packages: ['g++-6', 'clang-3.5', 'ninja-build']
 
     - name: "Linux clang++-3.6 unit tests"
+      stage: test
       os: linux
       compiler: clang
       env:
@@ -154,6 +202,7 @@ jobs:
           packages: ['g++-6', 'clang-3.6', 'ninja-build']
 
     - name: "Linux clang++-3.7 unit tests"
+      stage: test
       os: linux
       compiler: clang
       env:
@@ -165,6 +214,7 @@ jobs:
           packages: ['g++-6', 'clang-3.7', 'ninja-build']
 
     - name: "Linux clang++-3.8 unit tests"
+      stage: test
       os: linux
       compiler: clang
       env:
@@ -176,6 +226,7 @@ jobs:
           packages: ['g++-6', 'clang-3.8', 'ninja-build']
 
     - name: "Linux clang++-3.9 unit tests"
+      stage: test
       os: linux
       compiler: clang
       env:
@@ -187,6 +238,7 @@ jobs:
           packages: ['g++-6', 'clang-3.9', 'ninja-build']
 
     - name: "Linux clang++-4.0 unit tests"
+      stage: test
       os: linux
       compiler: clang
       env:
@@ -198,6 +250,7 @@ jobs:
           packages: ['g++-6', 'clang-4.0', 'ninja-build']
 
     - name: "Linux clang++-5.0 unit tests"
+      stage: test
       os: linux
       compiler: clang
       env:
@@ -209,6 +262,7 @@ jobs:
           packages: ['g++-6', 'clang-5.0', 'ninja-build']
 
     - name: "Linux clang++-6.0 unit tests"
+      stage: test
       os: linux
       compiler: clang
       env:
@@ -224,30 +278,37 @@ jobs:
     #################
 
     - <<: *osx_agent
+      stage: test
       name: "macOS xcode8.3 unit tests"
       osx_image: xcode8.3
 
     - <<: *osx_agent
+      stage: test
       name: "macOS xcode9 unit tests"
       osx_image: xcode9
 
     - <<: *osx_agent
+      stage: test
       name: "macOS xcode9.1 unit tests"
       osx_image: xcode9.1
 
     - <<: *osx_agent
+      stage: test
       name: "macOS xcode9.2 unit tests"
       osx_image: xcode9.2
 
     - <<: *osx_agent
+      stage: test
       name: "macOS xcode9.3 unit tests"
       osx_image: xcode9.3
 
     - <<: *osx_agent
+      stage: test
       name: "macOS xcode9.4 unit tests"
       osx_image: xcode9.4
 
     - <<: *osx_agent
+      stage: test
       name: "macOS xcode10 unit tests"
       osx_image: xcode10
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Travis Build Status](https://api.travis-ci.com/cppbits/Core.svg?branch=develop)](https://travis-ci.com/cppbits/Core)
 [![Appveyor Build Status](https://ci.appveyor.com/api/projects/status/g0av95jxa5fak93r/branch/develop?svg=true)](https://ci.appveyor.com/project/cppbits/Core)
+[![Coverage Status](https://coveralls.io/repos/github/cppbits/Core/badge.svg?branch=develop)](https://coveralls.io/github/cppbits/Core?branch=develop)
 [![Github Issues](https://img.shields.io/github/issues/cppbits/Core.svg)](http://github.com/cppbits/Core/issues)
 [![Tested Compilers](https://img.shields.io/badge/compilers-gcc%20%7C%20clang%20%7C%20msvc-blue.svg)](#tested-compilers)
 [![Documentation](https://img.shields.io/badge/docs-doxygen-blue.svg)](http://cppbits.github.io/Core)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -94,7 +94,7 @@ endif()
 # Code Coverage
 ##############################################################################
 
-if( BIT_CORE_ENABLE_COVERAGE AND NOT MSVC )
+if( BIT_CORE_ENABLE_COVERAGE )
   assert_clang_or_gcc()
 
   add_compile_options(
@@ -102,7 +102,9 @@ if( BIT_CORE_ENABLE_COVERAGE AND NOT MSVC )
     -O0
     -fprofile-arcs
     -ftest-coverage
+    --coverage
   )
+  link_libraries(--coverage)
 endif()
 
 ##############################################################################

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,22 +4,104 @@ cmake_minimum_required(VERSION 3.1)
 # Test Options
 ##############################################################################
 
-option(BIT_CORE_ENABLE_SANITIZER "Compile and run with sanitizers" OFF)
+option(BIT_CORE_ENABLE_MSAN "Compile and run with memory sanitizers" OFF)
+option(BIT_CORE_ENABLE_ASAN "Compile and run with address sanitizers" OFF)
+option(BIT_CORE_ENABLE_UBSAN "Compile and run with undefined behavior sanitizers" OFF)
+option(BIT_CORE_ENABLE_TSAN "Compile and run with thread sanitizers" OFF)
 option(BIT_CORE_ENABLE_COVERAGE "Compile with coverage information" OFF)
 option(BIT_CORE_ENABLE_VALGRIND "Compile and run with valgrind" OFF)
+
+##############################################################################
+# Utilities
+##############################################################################
+
+function(assert_clang_or_gcc)
+  if( NOT ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang" OR
+           "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU") )
+    message(FATAL_ERROR "Sanitizers require either GCC or clang.")
+  endif()
+endfunction()
+
+##############################################################################
+# Memory Sanitizer
+##############################################################################
+
+if( BIT_CORE_ENABLE_MSAN )
+  assert_clang_or_gcc()
+
+  add_compile_options(
+    -g
+    -O2
+    -fno-omit-frame-pointer
+    -fsanitize=memory
+  )
+  link_libraries(
+    -fsanitize=memory
+  )
+endif()
 
 ##############################################################################
 # Address Sanitizer
 ##############################################################################
 
-if( BIT_CORE_ENABLE_SANITIZER AND NOT MSVC )
+if( BIT_CORE_ENABLE_ASAN )
+  assert_clang_or_gcc()
+
   add_compile_options(
     -g
-    -O2
+    -O1
     -fno-omit-frame-pointer
     -fsanitize=address
     -fsanitize=leak
+  )
+  link_libraries(
+    -fsanitize=address
+    -fsanitize=leak
+  )
+endif()
+
+##############################################################################
+# UB Sanitizer
+##############################################################################
+
+if( BIT_CORE_ENABLE_UBSAN )
+  assert_clang_or_gcc()
+
+  add_compile_options(
     -fsanitize=undefined
+  )
+  link_libraries(
+    -fsanitize=undefined
+  )
+endif()
+
+##############################################################################
+# Thread Sanitizer
+##############################################################################
+
+if( BIT_CORE_ENABLE_UBSAN )
+  assert_clang_or_gcc()
+
+  add_compile_options(
+    -fsanitize=thread
+  )
+  link_libraries(
+    -fsanitize=thread
+  )
+endif()
+
+##############################################################################
+# Code Coverage
+##############################################################################
+
+if( BIT_CORE_ENABLE_COVERAGE AND NOT MSVC )
+  assert_clang_or_gcc()
+
+  add_compile_options(
+    -g
+    -O0
+    -fprofile-arcs
+    -ftest-coverage
   )
 endif()
 


### PR DESCRIPTION
This adds validation targets to CI.

The following targets are added:

* UB Sanitizer 
* Address Sanitizer
* Thread Sanitizer
* Code Coverage (with coveralls)

Memory sanitizer (MSAN) is currently disabled, as it triggers CI failures due to the standard library not being tooled for MSAN.